### PR TITLE
Proposal of changing log levels.

### DIFF
--- a/piax-agent/pom.xml
+++ b/piax-agent/pom.xml
@@ -48,6 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>

--- a/piax-agent/src/main/java/org/piax/agent/impl/AgentAttribs.java
+++ b/piax-agent/src/main/java/org/piax/agent/impl/AgentAttribs.java
@@ -77,16 +77,16 @@ public class AgentAttribs extends RowData {
     public synchronized void attach() {
         logger.debug("attach called");
         if (isAttached) {
-            logger.warn("duplicated attach call");
+            logger.info("duplicated attach call");
             return;
         }
         this.isBoundToAttribute = false;
         try {
             table.insertRow(this);
         } catch (IllegalStateException ignore) {
-            logger.error("", ignore);
+            logger.info("", ignore);
         } catch (IdConflictException ignore) {
-            logger.error("", ignore);
+            logger.info("", ignore);
         }
         this.bindToAttribute();
         isAttached = true;

--- a/piax-dht/pom.xml
+++ b/piax-dht/pom.xml
@@ -42,6 +42,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>

--- a/piax-gtrans-dtn/pom.xml
+++ b/piax-gtrans-dtn/pom.xml
@@ -48,6 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>

--- a/piax-gtrans/pom.xml
+++ b/piax-gtrans/pom.xml
@@ -49,6 +49,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>

--- a/piax-gtrans/src/main/java/org/piax/gtrans/RPCInvoker.java
+++ b/piax-gtrans/src/main/java/org/piax/gtrans/RPCInvoker.java
@@ -913,7 +913,7 @@ public class RPCInvoker<T extends RPCIf, E extends Endpoint> implements RPCIf {
             ret = new ReturnValue<Object>(e.getCause());
         } catch (Throwable e) {
             // any Exception or Error except for InvocationTargetException
-            logger.error("", e);
+            logger.info("", e);
             ret = new ReturnValue<Object>(e);
         }
         return ret;

--- a/piax-gtrans/src/main/java/org/piax/gtrans/util/ThroughTransport.java
+++ b/piax-gtrans/src/main/java/org/piax/gtrans/util/ThroughTransport.java
@@ -47,14 +47,12 @@ public class ThroughTransport<E extends PeerLocator> extends
     @Override
     protected Object _preSend(ObjectId sender, ObjectId receiver,
             E dst, Object msg) throws IOException {
-        System.out.print("*");
         return msg;
     }
 
     @Override
     protected Object _postReceive(ObjectId sender, ObjectId receiver,
             E src, Object msg) {
-        System.out.print("+");
         return msg;
     }
 }

--- a/piax-sample/pom.xml
+++ b/piax-sample/pom.xml
@@ -43,6 +43,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.6</version>
         <configuration>
           <descriptor>src/assembly/distribution.xml</descriptor>
         </configuration>


### PR DESCRIPTION
- AgentAttribs: It is strange to show as error/warning because they are ignored.
- RPCInvoker: Same as above. Besides, it is treated as an error at the caller side.
- ThroughTransport: They are garbage outputs.

(By these changes, `mvn test` does not show unnecessary error messages.)
