### PR TITLE
Use maven-bundle-plugin to include Export/Import-Pacakge in manifest.

### DIFF
--- a/piax-agent/pom.xml
+++ b/piax-agent/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <groupId>org.piax</groupId>
   <artifactId>piax-agent</artifactId>
+  <packaging>bundle</packaging>
   <version>3.2-SNAPSHOT</version>
   <name>PIAX Agent</name>
   <description>The mobile agent library of PIAX</description>
@@ -138,6 +139,17 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+	<artifactId>maven-bundle-plugin</artifactId>
+	<version>2.5.4</version>
+	<extensions>true</extensions>
+	<configuration>
+	  <instructions>
+	    <Export-Package>org.piax.agent.*</Export-Package>
+	  </instructions>
+	</configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/piax-dht/pom.xml
+++ b/piax-dht/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <groupId>org.piax</groupId>
   <artifactId>piax-dht</artifactId>
+  <packaging>bundle</packaging>
   <version>3.2-SNAPSHOT</version>
   <name>PIAX DHT</name>
   <url>http://www.piax.org</url>
@@ -64,6 +65,17 @@
               <value>src/test/resources/logging.properties</value>
             </property>
           </systemProperties>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.4</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>org.piax.*</Export-Package>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/piax-gtrans-dtn/pom.xml
+++ b/piax-gtrans-dtn/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <groupId>org.piax</groupId>
   <artifactId>piax-gtrans-dtn</artifactId>
+  <packaging>bundle</packaging>
   <version>3.2-SNAPSHOT</version>
   <name>PIAX GTrans DTN extension</name>
   <url>http://www.piax.org</url>
@@ -44,6 +45,17 @@
         <configuration>
           <source>8</source>
           <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.4</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>org.piax.*</Export-Package>
+          </instructions>
         </configuration>
       </plugin>
       <plugin>

--- a/piax-gtrans/pom.xml
+++ b/piax-gtrans/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <groupId>org.piax</groupId>
   <artifactId>piax-gtrans</artifactId>
+  <packaging>bundle</packaging>
   <version>3.2-SNAPSHOT</version>
   <name>PIAX GTrans</name>
   <description>The generic network transport library of PIAX</description>
@@ -158,6 +159,17 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+	  <groupId>org.apache.felix</groupId>
+	  <artifactId>maven-bundle-plugin</artifactId>
+	  <version>2.5.4</version>
+	  <extensions>true</extensions>
+	  <configuration>
+	    <instructions>
+	      <Export-Package>org.piax.*</Export-Package>
+	    </instructions>
+	  </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
以前大和から出したpull requestとほぼ同じですが、MANIFEST.MFに
Import-Package:
Export-Package:
のふたつの行を追加する変更です。これらはOSGi bundleの依存性管理に使われており、Import-Packageに
使っているパッケージ名、Export-Packageに提供しているパッケージ名が記載されます。
OSGiはこれらの情報に従ってbundleをロードします。この変更によりpiaxのjarがOSGiで使用可能になります。
これらの行を見ない実行環境(OSGi以外の環境)では影響ありません。

Import-Package,Export-Packageはnettyやasm, barchart-udtといったPIAXも使っている
ライブラリも提供している情報で、変なものでは無いはずです。